### PR TITLE
Potentially Fixed BungeeCord's Null on Leave Issue

### DIFF
--- a/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeServerListener.java
+++ b/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeServerListener.java
@@ -70,8 +70,18 @@ public class BungeeServerListener implements Listener {
     }
 
     void leave(ProxiedPlayer player, boolean isFake) {
-        if (isFake) chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), player.getServer().getInfo().getName(), this::sendToAllServersVanish);
-        else chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), player.getServer().getInfo().getName(), this::sendToAllServers);
+        // Bungee is "dumb" and needs to be delayed...
+        try {
+            plugin.getProxy().getScheduler().schedule(
+                    plugin,
+                    () -> {
+                        if (isFake) chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), player.getServer().getInfo().getName(), this::sendToAllServersVanish);
+                        else chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), player.getServer().getInfo().getName(), this::sendToAllServers);
+                    },
+                    50L, TimeUnit.MILLISECONDS);  // 50ms is 1 tick
+        } catch (Exception e) {
+            plugin.getLogger().warning("BungeeCord error. This is a bungeecord issue and cannot be fixed: " + e.getMessage());
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
# Pull Request

---

## Description

*This is a potential fix for `getServer()` returning `null` when a player leaves.*

Fixes #109 

---

## Type of Change

- [ ] Bug Fix (Small Non-Code Breaking Issue)
- [x] Bug Fix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [ ] Improvement (Improving An Existing Section of Code)
- [ ] Documentation Update
- [ ] Security Vulnerability

## Changes

- [x] Internal Code
- [ ] Documentation
- [ ] Other: _____

---

## Test Configuration
* Hardware:
    - CPU: AMD Ryzen 7 5800x3D
    - GPU: Nvidia RTX 3080
    - RAM: 32 GB DDR4
* JDK: Java OpenJDK 17

---

## Checklist

- [x] This pull request has been linked to the appropriate issue on GitHub. (Use the development section on the right.)
- [x] The code follows the style [guidelines](https://github.com/beanbeanjuice/SimpleProxyChat/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed on GitHub.
- [x] Appropriate comments and javadocs were added in your code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] Appropriate tests exist for this pull request.
- [x] New and existing Maven CI tests have passed.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Changes have been documented in the current draft [ProxyChat Releases](https://github.com/beanbeanjuice/SimpleProxyChat/releases) update.
