### PR TITLE
Fixed Previous Server Being Null

### DIFF
--- a/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeePreviousServerHandler.java
+++ b/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeePreviousServerHandler.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 
 public class BungeePreviousServerHandler {
 
+    // TODO: Use UUID, String is insecure.
     private final HashMap<String, ServerInfo> previousServers = new HashMap<>();
 
     public void put(final String playerName, final ServerInfo serverInfo) {

--- a/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeePreviousServerHandler.java
+++ b/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeePreviousServerHandler.java
@@ -3,18 +3,17 @@ package com.beanbeanjuice.simpleproxychat.utility.listeners.bungee;
 import net.md_5.bungee.api.config.ServerInfo;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 public class BungeePreviousServerHandler {
 
-    private final HashMap<UUID, ServerInfo> previousServers = new HashMap<>();
+    private final HashMap<String, ServerInfo> previousServers = new HashMap<>();
 
-    public void put(final UUID uuid, final ServerInfo serverInfo) {
-        previousServers.put(uuid, serverInfo);
+    public void put(final String playerName, final ServerInfo serverInfo) {
+        previousServers.put(playerName, serverInfo);
     }
 
-    public ServerInfo get(final UUID uuid) {
-        return previousServers.get(uuid);
+    public ServerInfo get(final String playerName) {
+        return previousServers.get(playerName);
     }
 
 }

--- a/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeServerListener.java
+++ b/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeServerListener.java
@@ -70,7 +70,7 @@ public class BungeeServerListener implements Listener {
     */
     @EventHandler
     public void onPlayerLeaveServer(ServerDisconnectEvent event) {
-        previousServerHandler.put(event.getPlayer().getUniqueId(), event.getTarget());
+        previousServerHandler.put(event.getPlayer().getName(), event.getTarget());
     }
 
     /*
@@ -79,7 +79,7 @@ public class BungeeServerListener implements Listener {
     */
     @EventHandler
     public void onPlayerKick(ServerKickEvent event) {
-        previousServerHandler.put(event.getPlayer().getUniqueId(), event.getKickedFrom());
+        previousServerHandler.put(event.getPlayer().getName(), event.getKickedFrom());
     }
 
     @EventHandler
@@ -95,8 +95,8 @@ public class BungeeServerListener implements Listener {
             plugin.getProxy().getScheduler().schedule(
                     plugin,
                     () -> {
-                        if (isFake) chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), previousServerHandler.get(player.getUniqueId()).getName(), this::sendToAllServersVanish);
-                        else chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), previousServerHandler.get(player.getUniqueId()).getName(), this::sendToAllServers);
+                        if (isFake) chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), previousServerHandler.get(player.getName()).getName(), this::sendToAllServersVanish);
+                        else chatHandler.runProxyLeaveMessage(player.getName(), player.getUniqueId(), previousServerHandler.get(player.getName()).getName(), this::sendToAllServers);
                     },
                     50L, TimeUnit.MILLISECONDS);  // 50ms is 1 tick
         } catch (Exception e) {

--- a/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeVanishListener.java
+++ b/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/bungee/BungeeVanishListener.java
@@ -19,7 +19,7 @@ public class BungeeVanishListener implements Listener {
 
     @EventHandler
     public void onVanish(BungeePlayerHideEvent event) {
-        listener.getPreviousServerHandler().put(event.getPlayer().getUniqueId(), event.getPlayer().getServer().getInfo());
+        listener.getPreviousServerHandler().put(event.getPlayer().getName(), event.getPlayer().getServer().getInfo());
 
         if (!config.getAsBoolean(ConfigDataKey.USE_FAKE_MESSAGES)) return;
 


### PR DESCRIPTION
# Pull Request

---

## Description

*There was an issue that caused the previous server to be null on Bungeecord for players without a UUID.*

Fixes #117 

---

## Type of Change

- [ ] Bug Fix (Small Non-Code Breaking Issue)
- [x] Bug Fix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [ ] Improvement (Improving An Existing Section of Code)
- [ ] Documentation Update
- [ ] Security Vulnerability

## Changes

- [x] Internal Code
- [ ] Documentation
- [ ] Other: _____

---

## Test Configuration
* Hardware:
    - CPU: AMD Ryzen 7 5800x3D
    - GPU: Nvidia RTX 3080
    - RAM: 32 GB DDR4
* JDK: Java OpenJDK 17

---

## Checklist

- [x] This pull request has been linked to the appropriate issue on GitHub. (Use the development section on the right.)
- [x] The code follows the style [guidelines](https://github.com/beanbeanjuice/SimpleProxyChat/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed on GitHub.
- [x] Appropriate comments and javadocs were added in your code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] Appropriate tests exist for this pull request.
- [x] New and existing Maven CI tests have passed.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Changes have been documented in the current draft [ProxyChat Releases](https://github.com/beanbeanjuice/SimpleProxyChat/releases) update.
