### PR TITLE
fix: [GH-280] Fix Dependabot Paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@ updates:
   - package-ecosystem: "gradle"
     directories:
       - ""
-      - "projects/SimpleProxyChat"
-      - "projects/SimpleProxyChatHelper"
+      - "projects/common"
+      - "projects/proxy"
+      - "projects/proxy/shared"
+      - "projects/proxy/velocity"
+      - "projects/proxy/bungeecord"
+      - "projects/server"
+      - "projects/server/shared"
+      - "projects/server/spigot"
     target-branch: "master"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Pull Request

---

## Description

[//]: # (Please include a summary of the changes you have made.)
The `dependabot.yml` paths were out of date. It now has the correct paths.

[//]: # (Make sure you link the correct GitHub Issue. E.g. Closes #44)
[//]: # (Please use N/A if not applicable.)
Closes GH-280.

[//]: # (Please include any PRs that are related. E.g. Related PRs: Blocks #99)
[//]: # (Please use N/A if not applicable.)
Related PRs: N/A

[//]: # (Please include any pre-requisites you needed to get this running. E.g. Prerequisites: Velocity v1.0.0)
Prerequisites: N/A

---

## Checklist

* The code follows the style [guidelines](https://github.com/beanbeanjuice/SimpleProxyChat/blob/master/CONTRIBUTING.md). 
* A self-review of the code was performed on GitHub.
* Appropriate comments and javadocs were added in your code.
* Appropriate changes have been made to the documentation.
* Appropriate changes have been made to the `README.md` file.
* Appropriate tests exist for this pull request.
