### PR TITLE
Allow chat events to be cancelled

### DIFF
--- a/projects/proxy/velocity/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/VelocityServerListener.java
+++ b/projects/proxy/velocity/src/main/java/com/beanbeanjuice/simpleproxychat/utility/listeners/VelocityServerListener.java
@@ -62,6 +62,7 @@ public class VelocityServerListener {
     @Subscribe(order = PostOrder.LAST)
     public void onPlayerChat(PlayerChatEvent event) {
         if (playerIsInDisabledServer(event.getPlayer(), plugin)) return;
+        if (!event.getResult().isAllowed()) return;
 
         String playerMessage = event.getMessage();
         Player player = event.getPlayer();


### PR DESCRIPTION
# Pull Request

---

## Description

[//]: # (Please include a summary of the changes you have made.)
Adds a simple condition check in `onPlayerChat` so that SimpleProxyChat will not send chat messages if the chat event was cancelled. Despite Velocity API marking PlayerChatEvent's result as deprecated, chat cancelling will still work if you have plugins like SignedVelocity installed.

[//]: # (Make sure you link the correct GitHub Issue. E.g. Closes #44)
[//]: # (Please use N/A if not applicable.)
Closes N/A

[//]: # (Please include any PRs that are related. E.g. Related PRs: Blocks #99)
[//]: # (Please use N/A if not applicable.)
Related PRs: N/A

[//]: # (Please include any pre-requisites you needed to get this running. E.g. Prerequisites: Velocity v1.0.0)
Prerequisites: N/A

---

## Checklist

* The code follows the style [guidelines](https://github.com/beanbeanjuice/SimpleProxyChat/blob/master/CONTRIBUTING.md). 
* A self-review of the code was performed on GitHub.
* Appropriate comments and javadocs were added in your code.
* Appropriate changes have been made to the documentation.
* Appropriate changes have been made to the `README.md` file.
* Appropriate tests exist for this pull request.
